### PR TITLE
Fixed error: Stored property 'color' of 'Sendable'-conforming struct 'ColorOp' has non-Sendable type 'QDColor'

### DIFF
--- a/QuickDrawViewer/QuickDrawColor.swift
+++ b/QuickDrawViewer/QuickDrawColor.swift
@@ -132,7 +132,7 @@ enum QD1Color : UInt32 {
 }
 
 // MARK: - QuickDraw Color Union
-enum QDColor : CustomStringConvertible {
+enum QDColor : CustomStringConvertible, Sendable {
 
   
   case rgb(rgb: RGBColor);


### PR DESCRIPTION
Thank you for creating this tool! It's been very handy for converting old Maelstrom game customization packs.

This PR fixes the only error I ran into when building and running using Xcode 26.4.